### PR TITLE
Fix checkov scan findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-white.svg)](https://choosealicense.com/licenses/unlicense/) [![GitHub pull-requests closed](https://img.shields.io/github/issues-pr-closed/kunduso/aws-eks-terraform)](https://github.com/kunduso/aws-eks-terraform/pulls?q=is%3Apr+is%3Aclosed) [![GitHub pull-requests](https://img.shields.io/github/issues-pr/kunduso/aws-eks-terraform)](https://GitHub.com/kunduso/aws-eks-terraform/pull/) 
+[![GitHub issues-closed](https://img.shields.io/github/issues-closed/kunduso/aws-eks-terraform)](https://github.com/kunduso/aws-eks-terraform/issues?q=is%3Aissue+is%3Aclosed) [![GitHub issues](https://img.shields.io/github/issues/kunduso/aws-eks-terraform)](https://GitHub.com/kunduso/aws-eks-terraform/issues/) 
+[![terraform-infra-provisioning](https://github.com/kunduso/aws-eks-terraform/actions/workflows/terraform.yml/badge.svg)](https://github.com/kunduso/aws-eks-terraform/actions/workflows/terraform.yml) 
+[![checkov-static-analysis-scan](https://github.com/kunduso/aws-eks-terraform/actions/workflows/code-scan.yml/badge.svg?branch=main)](https://github.com/kunduso/aws-eks-terraform/actions/workflows/code-scan.yml) 
+
+![EKS Architecture](https://via.placeholder.com/800x400/0066cc/ffffff?text=EKS+Cluster+Architecture)
+
+## Introduction
+The objective was to create a secure Amazon EKS (Elastic Kubernetes Service) cluster with all supporting infrastructure including VPC, security groups, IAM roles, and monitoring using **Terraform and GitHub Actions**.
+
+<br />This implementation follows AWS security best practices including:
+- Private EKS cluster endpoint configuration
+- KMS encryption for ECR repositories and CloudWatch logs
+- Least privilege IAM policies and security group rules
+- Automated security scanning with Checkov
+- Cost monitoring with Infracost (in pull requests)
+
+<br />The entire infrastructure is provisioned using Infrastructure as Code (IaC) principles with Terraform, and deployed through a fully automated pipeline using GitHub Actions.
+
+<br />This repository also includes **Infracost** estimates to monitor and control cloud costs. The pipeline automatically generates cost estimates for infrastructure changes in pull requests.
+
+<br />*Note: This implementation focuses on the core EKS infrastructure. Application deployments, ingress controllers, and service mesh configurations are not included in this repository.*
+
+## Architecture Components
+This repository provisions the following AWS resources:
+- **EKS Cluster** with private endpoint access and comprehensive logging
+- **VPC** with public subnets, internet gateway, and VPC Flow Logs
+- **EKS Node Groups** with auto-scaling configuration
+- **Security Groups** with least privilege access rules
+- **IAM Roles and Policies** for EKS cluster and worker nodes
+- **ECR Repository** with KMS encryption and image scanning
+- **CloudWatch Log Groups** with KMS encryption
+- **OIDC Provider** for service account integration
+- **KMS Keys** for encryption at rest
+
+## Prerequisites
+This repository uses a trusted OpenID connect identity provider in Amazon Identity and Access Management to provision AWS Cloud resources in the specified AWS account. You can read about it [here](https://skundunotes.com/2023/02/28/securely-integrate-aws-credentials-with-github-actions-using-openid-connect/) to get a detailed explanation with steps.
+<br />The `ARN` of the `IAM Role` is stored as a GitHub secret which is referred in the [`terraform.yml`](https://github.com/kunduso/aws-eks-terraform/blob/main/.github/workflows/terraform.yml) file.
+<br />As part of the *Infracost* integration, an `INFRACOST_API_KEY` was created and stored as a GitHub Actions secret. The cost estimate process was managed using a GitHub Actions variable `INFRACOST_SCAN_TYPE` where the value is either `hcl_code` or `tf_plan`, depending on the type of scan desired.
+
+## Usage
+Ensure that the policy attached to the IAM role whose credentials are being used in this configuration has permission to create and manage all the resources that are included in this repository.
+<br />
+<br />Review the code including the [`terraform.yml`](./.github/workflows/terraform.yml) to understand the steps in the GitHub Actions pipeline. Also review the `terraform` code to understand all the concepts associated with creating a secure EKS cluster, VPC, security groups, IAM roles, and encryption configurations.
+<br />If you want to check the pipeline logs, click on the **Build Badge** (terraform-infra-provisioning) above the image in this ReadMe.
+
+## Security Features
+This implementation includes several security best practices:
+- **Private EKS Endpoint**: Cluster API server is not publicly accessible
+- **KMS Encryption**: ECR repositories and CloudWatch logs are encrypted at rest
+- **Security Group Rules**: Specific ingress/egress rules following least privilege
+- **IAM Roles**: Separate roles for cluster and worker nodes with minimal permissions
+- **VPC Flow Logs**: Network traffic monitoring and analysis
+- **Image Scanning**: Automatic vulnerability scanning for container images
+- **Automated Security Scanning**: Checkov integration for infrastructure security validation
+
+## Contributing
+If you find any issues or have suggestions for improvement, feel free to open an issue or submit a pull request. Contributions are always welcome!
+
+## License
+This code is released under the Unlicense License. See [LICENSE](LICENSE).

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,6 +1,61 @@
+# KMS key for CloudWatch logs encryption
+resource "aws_kms_key" "cloudwatch_kms_key" {
+  description             = "KMS key for CloudWatch logs encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  
+  tags = {
+    Name = "${var.name}-encrypt-cloudwatch-logs"
+  }
+}
+
+resource "aws_kms_key_policy" "cloudwatch_key_policy" {
+  key_id = aws_kms_key.cloudwatch_kms_key.key_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow CloudWatch Logs"
+        Effect = "Allow"
+        Principal = {
+          Service = "logs.${data.aws_region.current.name}.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/${var.name}-cluster/cluster"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "cloudwatch_key_alias" {
+  name          = "alias/${var.name}-encrypt-cloudwatch-logs"
+  target_key_id = aws_kms_key.cloudwatch_kms_key.key_id
+}
+
 resource "aws_cloudwatch_log_group" "eks_cluster" {
   name              = "/aws/eks/${var.name}-cluster/cluster"
   retention_in_days = 365
+  kms_key_id        = aws_kms_key.cloudwatch_kms_key.arn
 
   tags = {
     Name        = "${var.name}-eks-cloudwatch-log-group"

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -3,7 +3,7 @@ resource "aws_kms_key" "cloudwatch_kms_key" {
   description             = "KMS key for CloudWatch logs encryption"
   deletion_window_in_days = 7
   enable_key_rotation     = true
-  
+
   tags = {
     Name = "${var.name}-encrypt-cloudwatch-logs"
   }

--- a/infra/ecr-kms.tf
+++ b/infra/ecr-kms.tf
@@ -1,0 +1,82 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  principal_root_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+}
+# Create a KMS key for encryption
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "ecr_kms_key" {
+  description             = "KMS key to encrypt ECR images in central AWS account."
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  tags                    = { "Name" = "${var.name}-encrypt-ecr" }
+}
+# KMS key policy allowing AccountB to use the key for ECR image encryption/decryption
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
+resource "aws_kms_alias" "ecr_key_alias" {
+  name          = "alias/${var.name}-encrypt-ecr"
+  target_key_id = aws_kms_key.ecr_kms_key.key_id
+}
+
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
+resource "aws_kms_key_policy" "ecr_key_policy" {
+  key_id = aws_kms_key.ecr_kms_key.key_id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Allow Central AWS account to perform any KMS actions
+      {
+        Sid    = "Enable IAM User Permissions"
+        Action = ["kms:*"]
+        Effect = "Allow"
+        Principal = {
+          AWS = "${local.principal_root_arn}"
+        }
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow ECR to use the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecr.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:ReEncrypt*",
+          "kms:CreateGrant",
+          "kms:RetireGrant"
+        ]
+        Resource = aws_kms_key.ecr_kms_key.arn
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "ecr.${data.aws_region.current.name}.amazonaws.com"
+          },
+          StringLike = {
+            "kms:EncryptionContext:aws:ecr:arn" : "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"
+          }
+        }
+      },
+      {
+        Sid    = "Allow EKS nodes to decrypt ECR images"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.eks_nodes.arn
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = aws_kms_key.ecr_kms_key.arn
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "ecr.${data.aws_region.current.name}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,6 +1,10 @@
 resource "aws_ecr_repository" "image_repo" {
   name                 = var.name
   image_tag_mutability = "IMMUTABLE"
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.ecr_kms_key.arn
+  }
   image_scanning_configuration {
     scan_on_push = true
   }
@@ -12,8 +16,6 @@ resource "aws_ecr_repository" "image_repo" {
 # Add repository policy to allow EKS nodes to pull images
 resource "aws_ecr_repository_policy" "repo_policy" {
   repository = aws_ecr_repository.image_repo.name
-
-
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/infra/eks-cluster.tf
+++ b/infra/eks-cluster.tf
@@ -6,8 +6,8 @@ resource "aws_eks_cluster" "main" {
   vpc_config {
     security_group_ids      = [aws_security_group.eks_cluster.id]
     subnet_ids              = module.vpc.public_subnets[*].id
-    endpoint_private_access = false
-    endpoint_public_access  = true
+    endpoint_private_access = true
+    endpoint_public_access  = false
   }
 
   enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -13,8 +13,6 @@ terraform {
 
 provider "aws" {
   region     = var.region
-  access_key = var.access_key
-  secret_key = var.secret_key
   default_tags {
     tags = {
       Source = "https://github.com/kunduso/aws-eks-terraform"

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 provider "aws" {
-  region     = var.region
+  region = var.region
   default_tags {
     tags = {
       Source = "https://github.com/kunduso/aws-eks-terraform"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -4,20 +4,6 @@ variable "region" {
   type        = string
   default     = "us-east-2"
 }
-#Define IAM User Access Key
-variable "access_key" {
-  description = "The access_key that belongs to the IAM user"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-#Define IAM User Secret Key
-variable "secret_key" {
-  description = "The secret_key that belongs to the IAM user"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
 variable "name" {
   description = "The name of the application."
   type        = string


### PR DESCRIPTION
The changes in this pull request closes #2, closes #4, closes #10 and other checkov findings:
`CKV_AWS_136`: Ensure that ECR repositories are encrypted using KMS
`CKV_AWS_39`: AWS EKS cluster endpoint access publicly enabled
`CKV_AWS_38`: AWS EKS cluster security group overly permissive to all traffic
`CKV_AWS_158`: AWS CloudWatch Log groups encrypted using default encryption key instead of KMS CMK